### PR TITLE
fix for IBM IKS

### DIFF
--- a/env-ibm/myvalues.yaml
+++ b/env-ibm/myvalues.yaml
@@ -1,1 +1,12 @@
 # Override configuration from https://github.com/jenkins-x/jenkins-x-platform/blob/master/values.yaml
+monocular:
+  mongodb:
+    persistence:
+      enabled: false 
+# Smaller cluster configurations require more time   
+jenkins:
+  Master:
+    Readiness:
+      InitialDelaySeconds: 600
+    Liveness:
+      InitialDelaySeconds: 660


### PR DESCRIPTION
Issues:
1. Smaller IKS cluster configurations require more time for jenkins pod to start.
2. Old  bitnami/mongodb:3.4.9-r1 image need to be updated to fix bug: https://github.com/jenkins-x/jx/issues/759
3. monocular:mongodb pod requires more time to start.

I wasn't able to figure out how to configure initialDelaySeconds for monocular:mongodb as it is not using Values in the version being used. I disabled persistence for monocular for now

