### PR TITLE
No need to install docker registry in AKS by default

### DIFF
--- a/env-aks/myvalues.yaml
+++ b/env-aks/myvalues.yaml
@@ -7,3 +7,6 @@ PipelineSecrets:
     {
       "credsStore": "acr-linux"
     }
+    
+docker-registry:
+  enabled: false    


### PR DESCRIPTION
Fixes https://github.com/jenkins-x/jx/issues/1805
Fixes https://github.com/jenkins-x/jx/issues/1367