### PR TITLE
Update myvalues.yaml for jenkins-x/charts PR 9

### DIFF
--- a/env-minishift/myvalues.yaml
+++ b/env-minishift/myvalues.yaml
@@ -53,12 +53,11 @@ jenkins:
       value: "hudson.model.View.Delete:admin"
     - name: "permission"
       value: "hudson.scm.SCM.Tag:admin"
-    SecurityRealmClass: "hudson.security.HudsonPrivateSecurityRealm"
-    SecurityRealmAttributes:
-    - name: "disableSignup"
-      value: "true"
-    - name: "enableCaptcha"
-      value: "false"
+    SecurityRealm: |-
+     <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
+       <disableSignup>true</disableSignup>
+       <enableCaptcha>false</enableCaptcha>
+     </securityRealm>
   Global:
     EnvVars:
       DOCKER_REGISTRY: "docker-registry.default.svc:5000"

--- a/env-openshift/myvalues.yaml
+++ b/env-openshift/myvalues.yaml
@@ -52,12 +52,11 @@ jenkins:
       value: "hudson.model.View.Delete:admin"
     - name: "permission"
       value: "hudson.scm.SCM.Tag:admin"
-    SecurityRealmClass: "hudson.security.HudsonPrivateSecurityRealm"
-    SecurityRealmAttributes:
-    - name: "disableSignup"
-      value: "true"
-    - name: "enableCaptcha"
-      value: "false"
+    SecurityRealm: |-
+     <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
+       <disableSignup>true</disableSignup>
+       <enableCaptcha>false</enableCaptcha>
+     </securityRealm>
   Global:
     EnvVars: 
       DOCKER_REGISTRY: "docker-registry.default.svc:5000"


### PR DESCRIPTION
This commit updates the `myvalues.yaml` in accordance with the PR [found in the jenkins-x/charts](https://github.com/jenkins-x/charts/pull/9).

@daveconde: could you have a quick look at the changes to make sure they are okay.

@jstrachan: I am still not 100% on how this can be introduced smoothly, especially since there are most likely people out there using the current config. Do you think it would make sense to re-add the old values `SecurityRealmClass` and `SecurityRealmAttributes` to the jenkins-x chart template? Something like: 
```
{{- if .Values.Master.SecurityRealm }}
	{{ .Values.Master.SecurityRealm | indent 6 }}
{{- else if  .Values.Master.SecurityRealmClass }}
      <securityRealm class="{{ .Values.Master.SecurityRealmClass }}">	
        {{- range $attribute := .Values.Master.SecurityRealmAttributes }}
          <{{- $attribute.name }}>{{- $attribute.value }}</{{- $attribute.name }}>	
      </securityRealm>
{{- else }}
      <securityRealm class="hudson.security.LegacySecurityRealm"/>
      </securityRealm>
{{- end }}
```
They could be deprecated and removed in a couple of months.

At least it wouldn't just break on people on upgrade - or worse, not break but just suddenly start using legacy security.