### PR TITLE
Pull in some changes for JX setup on IBM k8s (iks)

### DIFF
--- a/env-iks/README.md
+++ b/env-iks/README.md
@@ -103,14 +103,14 @@ NOTE: If you run into problems or want to customize parts of the setup, follow t
 
 * Make block default
 
-```
+```bash
     kubectl patch storageclass ibmc-file-bronze -p \
         '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 ```
 
 * Alternatively (if included in your plan) you can also choose `ibmc-block-silver` or `ibmc-block-gold` for better IOPS
 
-```
+```bash
     kubectl patch storageclass ibmc-block-bronze -p \
         '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 ```
@@ -121,7 +121,7 @@ WARNING: This does not work and needs further testing/investigation!
 
 Note: There is also a jenkins- addon, may work but never tested with IBM Cloud
 
-```
+```bash
 helm install \
     --namespace=kube-system \
     --name=cert-manager stable/cert-manager \
@@ -149,7 +149,7 @@ EOF
 * answer Y to create ingress when asked,
 * Specify `--http=false --tls-acme=true` if you have configured https
 
-```
+```bash
 jx install cluster --provider=iks \
     --domain='jx-wdc07.us-east.containers.appdomain.cloud' \
     [ --default-admin-password=<password> ] \ 

--- a/env-iks/README.md
+++ b/env-iks/README.md
@@ -1,5 +1,7 @@
 # Base Jenkins X IBM Cloud environment
 
+CAUTION: Current `iks` clusters need `kaniko` if you want to use them for building Docker images in the course of your CI pipeline (which is an essential step to get your applications into your JX k8s cluster). This is not yet implemented, cf. https://github.com/jenkins-x/jx/issues/3971.
+
 ## Prerequisites
 
 * Make yourself familiar with the general Jenkins-X (JX) setup: https://jenkins-x.io/documentation/
@@ -184,7 +186,7 @@ NOTE: This is only a snapshot, check out their state or if others exist meanwhil
 | JX environments are not created automatically                             | [#2985](https://github.com/jenkins-x/jx/issues/2985) |   -   |
 | Cluster registry is not automatically created                             | [#2997](https://github.com/jenkins-x/jx/issues/2997) |   -   |
 | `batch-mode`, `verbose`-Flag etc. not possible                            | [#2996](https://github.com/jenkins-x/jx/issues/2996) |   -   |
-
+| IKS needs `kaniko` to perform builds                                      | [#3971](https://github.com/jenkins-x/jx/issues/3971) |   -   |
 ----
 
 ## Appendix

--- a/env-iks/README.md
+++ b/env-iks/README.md
@@ -1,62 +1,132 @@
 # Base Jenkins X IBM Cloud environment
 
+## Prerequisites
+
+* Make yourself familiar with the general Jenkins-X (JX) setup: https://jenkins-x.io/documentation/
+* You need a GitHub account: https://github.com (Checkout the appendix of this document, if you would like to use IBM Cloud Git instead)
+* Before setting up (JX) on IBM cloud with Kubernetes (IKS) you need an IBM account. 
+You can apply for a free trial for one year here: https://www.ibm.com/partners/start/cloud-container-service/
+
+NOTE: A _free_ IBM cloud account does not include all necessary permissions and resources to run k8s and JX. 
+
+## Initial cloud setup
+
+### Automatic initial setup
+
+Run the following shell script, it should setup the local cloud tools (`ibmcloud`) on your machine.
+
+    # An IKS 1.10 cluster must be used, 1.11 was broken with jenkins-x at the time of writing
+    curl -sL https://ibm.biz/idt-installer | bash
+    
+### Manual initial setup
+
+If the automatic setup fails, you may perform a manual setup, as described here: https://console.bluemix.net/docs/cli/index.html#overview
+
+And install some additional plugins
+
+    ibmcloud plugin install container-service
+    ibmcloud plugin install container-registry
+
+and some tools used by JX
+
+* install latest helm -> https://docs.helm.sh/using_helm/#installing-helm
+* install kubectl 1.10 -> https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-binary-using-curl
+* install jx -> https://jenkins-x.io/getting-started/install/
+
+Then login to the IBM cloud
+
+    ibmcloud login -a https://api.us-east.bluemix.net (--sso / --apikey as appropriate)
+
+## Create/Install k8s/JX
+
+NOTE: Check out the open issues section at the end of the document (before the Appendix section) for some known limitations!
+
+### Create IKS cluster and JX automatically
+
+One of the large strengths of JX is, that it can even set up a k8s cluster automatically during the install process.
+
+Just call:
+
+```bash
+jx create cluster iks \
+   -n jx-wdc04 \
+   -r us-east \
+   -z wdc04 \
+   -m b2c.4x16 \
+   --workers=3 \
+   --kube-version=1.10.12 \
+   \
+   --namespace='jx'
 ```
-# An IKS 1.10 cluster must be used, 1.11 was broken with jenkins-x at the time of writing
-curl -sL https://ibm.biz/idt-installer | bash
-# These should be installed already but just in case...
-ibmcloud plugin install container-service
-ibmcloud plugin install container-registry
 
-# install latest helm -> https://docs.helm.sh/using_helm/#installing-helm
-# install kubectl 1.10 -> https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-binary-using-curl
-# install jx -> https://jenkins-x.io/getting-started/install/
+and answer some remaining questions, e.g., for your Git/GitHub user.
 
-ibmcloud login -a https://api.us-east.bluemix.net (--sso / --apikey as appropriate)
-# paygo account with write access to cluster being targetted (can be a trial but not a free cluster, won't work)
+NOTE: If you run into problems or want to customize parts of the setup, follow the instructions in the next section.
 
-# Find a region
-ibmcloud ks regions
+### Set up IKS and JX manually
 
-# Set the region ex. us-east
-ibmcloud ks region-set us-east
+#### Set up IKS cluster manually
 
-# Find a zone (eg. wdc07)
-ibmcloud ks zones
+* Find a region: `ibmcloud ks regions`
+* Set the region (eg. us-east, cf. [issue 2984](https://github.com/jenkins-x/jx/issues/2984)): `ibmcloud ks region-set us-east`
+* Find a zone (eg. wdc07): `ibmcloud ks zones`
+* Find machine types (should use `b2c.4x16 minimum`): `ibmcloud ks machine-types --zone wdc07`
+* Find the k8s 1.10.x version: `ibmcloud ks kube-versions`
+* Find the Public and private vlans (if none exist, they will be created): `ibmcloud ks vlans --zone wdc07`
+* Create VLANs, if vlans exist in the zone, they will need to be specified here otherwise they will be created.
+  If you want to use let's encrypt make sure to specify a cluster name so that `docker-registry.jx.<clustername>.<regionname>.containers.appdomain.cloud` is less than 64 characters (will be checked automatically during install), eg., `docker-registry.jx.jx-wdc07.us-east.container.appdomain.cloud < 64 chars` (Smallest possible is best).
+* Set up the cluster (some parameters depend on your settings before or what resource types are available in the chosen region, zone etc.):
 
-# Find machine types (should use b2c.4x16 minimum) 
-ibmcloud ks machine-types --zone wdc07
+```bash
+    ibmcloud ks cluster-create \
+        --name jx-wdc07 \
+        --kube-version 1.10.12 \ 
+        --zone wdc07 \
+        --machine-type b2c.4x16 \
+        --workers 3 \
+        [--private-vlan 2323675 --public-vlan 2323691]
+```
 
-#Find the 1.10.x version
-ibmcloud ks kube-versions
+* Check until state is "normal" (takes about 25 minutes): `ibmcloud ks cluster-get --cluster jx-wdc07`
+* Import cluster parameters to your shell environment: `eval $(ibmcloud ks cluster-config --export --cluster jx-wdc07)`
 
-#Find the Public and private vlans (if none exist, they will be created)
-ibmcloud ks vlans --zone wdc07
+#### Setup block storage drivers (Optional)
 
-# create command. If vlans exist in the zone, they will need to be specified here otherwise they will be created
-# If you want to use let's encrypt make sure to specify a cluster name so that docker-registry.jx.<clustername>.<regionname>.containers.appdomain.cloud is less than 64 characters
-# ex. docker-registry.jx.jx-wdc07.us-east.container.appdomain.cloud < 64 chars
-# (Smallest possible is best)
-ibmcloud ks cluster-create --name jx-wdc07 --kube-version 1.10.8 --zone wdc07 --machine-type b2c.4x16 --workers 3 --hardware shared [--private-vlan 2323675 --public-vlan 2323691]
+* Install block storage drives with helm
 
-# Check until state is "normal (takes about 15 minutes)
-ibmcloud ks cluster-get jx-wdc07
+```bash
+    helm init
+    helm repo add ibm  https://registry.bluemix.net/helm/ibm
+    helm repo update
+    helm install ibm/ibmcloud-block-storage-plugin --name ibmcloud-block-storage-plugin
+```
 
-# target cluster
-$(ibmcloud ks cluster-config --export jx-wdc07)
+* Make block default
 
-# Install block storage drivers
-helm init
-helm repo add ibm  https://registry.bluemix.net/helm/ibm
-helm repo update
-helm install ibm/ibmcloud-block-storage-plugin --name ibmcloud-block-storage-plugin
-# Make block default
-kubectl patch storageclass ibmc-file-bronze -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
-# you can also choose ibmc-block-silver or ibmc-block-gold for better IOPS
-kubectl patch storageclass ibmc-block-bronze -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+```
+    kubectl patch storageclass ibmc-file-bronze -p \
+        '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+```
 
-# This is if you want https (recommended) There is also a jenkins- addon, may work but never tested with IBM Cloud
-# <https>
-helm install --namespace=kube-system --name=cert-manager stable/cert-manager --set=ingressShim.defaultIssuerKind=ClusterIssuer --set=ingressShim.defaultIssuerName=letsencrypt-staging
+* Alternatively (if included in your plan) you can also choose `ibmc-block-silver` or `ibmc-block-gold` for better IOPS
+
+```
+    kubectl patch storageclass ibmc-block-bronze -p \
+        '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+```
+
+#### Setup https (Recommended)
+
+WARNING: This does not work and needs further testing/investigation!
+
+Note: There is also a jenkins- addon, may work but never tested with IBM Cloud
+
+```
+helm install \
+    --namespace=kube-system \
+    --name=cert-manager stable/cert-manager \
+    --set=ingressShim.defaultIssuerKind=ClusterIssuer \
+    --set=ingressShim.defaultIssuerName=letsencrypt-staging
 cat << EOF| kubectl create -n kube-system -f -
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: ClusterIssuer
@@ -70,36 +140,72 @@ spec:
       name: letsencrypt-staging
     http01: {}
 EOF
-# </https>
+```
 
-# you will need a github user and token and your cluster subdomain for the domain flag (example provided), answer Y to create ingress when asked. Choose IBM provider
-# specify --http=false --tls-acme=true if you have configured https
-jx install --default-admin-password=<password> --no-default-environments=true --docker-registry='registry.ng.bluemix.net' --domain='jx-wdc07.us-east.containers.appdomain.cloud' --provider='ibm' [--http=false --tls-acme=true ]
+#### Install JX manually
 
-# wait until done. can check status by doing kubectl get deployments,services,pvc,pv,ingress -n jx in another terminal
+* Have your GitHub account at hand,
+* Have your cluster subdomain for the domain flag (example provided) at hand,
+* answer Y to create ingress when asked,
+* Specify `--http=false --tls-acme=true` if you have configured https
 
-# Make sure you can push and pull images into the account you do this in:
-ibmcloud cr token-add --non-expiring --readwrite --description "Jenkins-X Token"
+```
+jx install cluster --provider=iks \
+    --domain='jx-wdc07.us-east.containers.appdomain.cloud' \
+    [ --default-admin-password=<password> ] \ 
+    [ --http=false --tls-acme=true ]
+```
 
-# Copy the "Token"
-echo -n token:<Token here> | base64 -w0
+* wait until done. can check status by doing `kubectl get deployments,services,pvc,pv,ingress -n jx` in another terminal
+* Make sure you can push and pull images into the account you do this in: `ibmcloud cr token-add --non-expiring --readwrite --description "Jenkins-X Token"`
 
-# Copy the base64 value and create a file call config.json with this contents:
-{
+## Open issues
+
+There are some open issues at the time of this writing (2019-02-05), some of which may limit your usage of IKS.
+
+NOTE: This is only a snapshot, check out their state or if others exist meanwhile: https://github.com/jenkins-x/jx/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3Aarea%2FIKS+
+
+| *Limitation*                                                              | *GitHub Issue*                                       | *WIP* |
+| ------------------------------------------------------------------------- |:----------------------------------------------------:|:-----:|
+| Currently it is only possible to create a cluster in the region *us-east* | [#2984](https://github.com/jenkins-x/jx/issues/2984) |   -   |
+| JX environments are not created automatically                             | [#2985](https://github.com/jenkins-x/jx/issues/2985) |   -   |
+| Cluster registry is not automatically created                             | [#2997](https://github.com/jenkins-x/jx/issues/2997) |   -   |
+| `batch-mode`, `verbose`-Flag etc. not possible                            | [#2996](https://github.com/jenkins-x/jx/issues/2996) |   -   |
+
+----
+
+## Appendix
+
+These setups are usually not necessary.
+
+### Create Docker secret
+
+* `kubectl --namespace default create secret docker-registry registrysecret --docker-server=registry.<region>.bluemix.net --docker-username=token --docker-password=<token_value> --docker-email=<email>`
+* Copy the "Token"
+
+    echo -n token:<Token here> | base64 -w0
+
+* Copy the base64 value and create a file called `config.json` with this contents:
+
+```{
   "auths": {
     "registry.ng.bluemix.net": {
       "auth": "<base64 encoded token>"
     }
   }
 }
-
-kubectl delete secret jenkins-docker-cfg -n jx
-kubectl create secret generic jenkins-docker-cfg --from-file=./config.json -n jx
-
-# At this point the jenkins server needs to restarted to pick up the new docker creds
-kubectl -njx delete pods -lapp=jenkins
-
-# If you want to use git.ng.bluemix.net (gitlab), create a personal access token there
-jx create git server gitlab https://git.ng.bluemix.net -n gitlab
-jx create git token -n gitlab -t <gitlab token> <gitlab username> 
 ```
+
+* Replace the existing Docker secret
+
+    kubectl delete secret jenkins-docker-cfg -n jx
+    kubectl create secret generic jenkins-docker-cfg --from-file=./config.json -n jx
+
+* At this point the jenkins server needs to restarted to pick up the new docker creds: `kubectl -njx delete pods` -lapp=jenkins
+
+### Use IBM Git
+
+If you want to use git.ng.bluemix.net (gitlab), create a personal access token there
+
+    jx create git server gitlab https://git.ng.bluemix.net -n gitlab
+    jx create git token -n gitlab -t <gitlab token> <gitlab username> 


### PR DESCRIPTION
I have spent some time to get JX running on IBM kubernetes - starting from the works provided by some IBM guys in last October. There are still some open bugs (in particular jenkins-x/jx#3971) which will prevent the setup of a fully usable `iks` cluster for JX. Nevertheless this PR contains some valuable updates to the setup process and some background information for any other user who will give it a try.