### PR TITLE
Configure tekton in alibaba

### DIFF
--- a/env-alibaba/myvalues.yaml
+++ b/env-alibaba/myvalues.yaml
@@ -12,3 +12,6 @@ monocular:
 nexus:
   persistence:
     size: 20Gi
+tekton:
+  pvc:
+    size: 20Gi


### PR DESCRIPTION
/hold this does not work because tekton is installed individually and not part of the platform. 

It would need to have the tekton values in the top level

```yaml
pvc:
  size: 20Gi
```