### PR TITLE
fix: put tekton config in the top level

### DIFF
--- a/env-alibaba/myvalues.yaml
+++ b/env-alibaba/myvalues.yaml
@@ -12,6 +12,7 @@ monocular:
 nexus:
   persistence:
     size: 20Gi
-tekton:
-  pvc:
-    size: 20Gi
+# Tekton config
+# Because tekton is installed individually and not part of the platform its config needs to be in the top level
+pvc:
+  size: 20Gi


### PR DESCRIPTION
Because tekton is installed individually and not part of the platform its
config needs to be in the top level
See https://github.com/jenkins-x/jx/pull/4154