### PR TITLE
chore(dependencies): update jenkins-x/jenkins-x-platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CHART_REPO := http://chartmuseum.jenkins-x.io
 CHART := jenkins-x-platform
-CHART_VERSION := 0.0.3321
+CHART_VERSION := 2.0.784
 OS := $(shell uname)
 HELM := $(shell command -v helm 2> /dev/null)
 WATCH := $(shell command -v watch --help 2> /dev/null)

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[jenkins-x/jenkins-x-platform](https://github.com/jenkins-x/jenkins-x-platform) |  | [2.0.784](https://github.com/jenkins-x/jenkins-x-platform/releases/tag/2.0.784) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: jenkins-x
+  repo: jenkins-x-platform
+  url: https://github.com/jenkins-x/jenkins-x-platform
+  version: 2.0.784
+  versionURL: https://github.com/jenkins-x/jenkins-x-platform/releases/tag/2.0.784


### PR DESCRIPTION
Update [jenkins-x/jenkins-x-platform](https://github.com/jenkins-x/jenkins-x-platform) from 0.0.3321 to [2.0.784](https://github.com/jenkins-x/jenkins-x-platform/releases/tag/2.0.784)

Command run was `jx step create pr make --name CHART_VERSION --version 2.0.784 --repo https://github.com/jenkins-x/cloud-environments.git`
<hr />

Update [jenkins-x/jenkins-x-platform](https://github.com/jenkins-x/jenkins-x-platform) to [2.0.784](https://github.com/jenkins-x/jenkins-x-platform/releases/tag/2.0.784)

Command run was `/Users/pmuir/go/src/github.com/jenkins-x/jx/build/jx step create pr make --name CHART_VERSION --version 2.0.784 --repo https://github.com/jenkins-x/cloud-environments.git`
<hr />

Update [jenkins-x/jenkins-x-platform](https://github.com/jenkins-x/jenkins-x-platform) to [2.0.784](https://github.com/jenkins-x/jenkins-x-platform/releases/tag/2.0.784)

Command run was `jx step create pr make --name CHART_VERSION --version 2.0.784 --repo https://github.com/jenkins-x/cloud-environments.git`
<hr />

Update [jenkins-x/jenkins-x-platform](https://github.com/jenkins-x/jenkins-x-platform) to [2.0.784](https://github.com/jenkins-x/jenkins-x-platform/releases/tag/2.0.784)

Command run was `/Users/pmuir/go/src/github.com/jenkins-x/jx/build/jx step create pr make --name CHART_VERSION --version 2.0.784 --repo https://github.com/jenkins-x/cloud-environments.git`